### PR TITLE
Update flickrtouchr.py

### DIFF
--- a/flickrtouchr.py
+++ b/flickrtouchr.py
@@ -187,7 +187,7 @@ def getphoto(id, token, filename):
         data = response.read()
     
         # Save the file!
-        fh = open(filename, "w")
+        fh = open(filename, "wb")
         fh.write(data)
         fh.close()
 


### PR DESCRIPTION
Update the default file open mode to binary mode. As by default, python on Windows uses text mode for file writing, which finally generates broken JPG files.